### PR TITLE
Added source repository and issue tracker to PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -55,7 +55,11 @@ ArchiveURL     := Concatenation("https://github.com/gap-packages/subsemi/",
                    "releases/download/v", ~.Version,
                    "/subsemi-", ~.Version),
                    ArchiveFormats := ".tar.gz .tar.bz2",
-
+SourceRepository := rec( 
+  Type := "git", 
+  URL := "https://github.com/gap-packages/subsemi"
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
 AbstractHTML := "<span class=\"pkgname\">SubSemi</span> is  a <span class=\
                    \"pkgname\">GAP</span> \
                    for enumerating subsemigroups.",


### PR DESCRIPTION
This PR adds new optional components from the PackageInfo.g template
(https://github.com/gap-packages/example/blob/master/PackageInfo.g):
* Type and the URL of the source code repository
* URL of the public issue tracker